### PR TITLE
Fix for PHP linting problems

### DIFF
--- a/Syntaxes/HTML 5.tmLanguage
+++ b/Syntaxes/HTML 5.tmLanguage
@@ -9,7 +9,6 @@
 		<string>shtml</string>
 		<string>xhtml</string>
 		<string>phtml</string>
-		<string>php</string>
 		<string>inc</string>
 		<string>tmpl</string>
 		<string>tpl</string>


### PR DESCRIPTION
Hi,

This patch fixes problems when the HTML5 package is installed along with one of the linter plugins.

Unfortunately, the HTML5 package marks .php files as being HTML5 syntax, which prevents the linter plugins from doing syntax checking against .php files.  The linter plugins are looking for files with the 'PHP' syntax, and have no way of knowing that there's PHP inside files marked as HTML5 syntax.

Best regards,
Stu
